### PR TITLE
DTM vs DSM

### DIFF
--- a/mat/mat.tex
+++ b/mat/mat.tex
@@ -177,7 +177,7 @@ For example for a DTM we can follow the convention that the `ground side' of the
 	\centering
 	\begin{subfigure}{0.4\linewidth}
 		\includegraphics[width=\linewidth]{figs/object_earth.pdf}
-		\subcaption{The interior and exterior of a DTM.}
+		\subcaption{The interior and exterior of a DSM.}
 	\label{fig:object_earth}
 	\end{subfigure}
 	\quad


### PR DESCRIPTION
The zoomed-in illustration shows a DSM surface with structures on top of the terrain.
the book uses DTM for both 7.4a and 7.4b, even though 7.4b shows objects on top of the terrain (which would strictly be called a DSM). Keeping the book's terminology here since it doesn't affect the MAT discussion.
just felt pointing